### PR TITLE
docs: add error troubleshooting reference

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -198,6 +198,58 @@ package modernc.org/sqlite: build constraints exclude all Go files
   golangci-lint run --timeout=10m
   ```
 
+## Chronicle Error Reference
+
+Chronicle exposes sentinel errors and typed wrappers from `errors.go`. Use
+`errors.Is` for sentinel checks and `errors.As` when you need wrapper details
+such as the query, metric, field, or storage path.
+
+### Sentinel errors
+
+| Error | Typical message | What it means | Troubleshooting steps |
+|---|---|---|---|
+| `ErrClosed` | `database is closed` | A read, write, or query used a DB handle after `Close()`. | Check lifecycle ownership, defer `Close()` only after all workers stop, and avoid reusing handles across tests. |
+| `ErrQueryTimeout` | `query timeout` | The query exceeded its configured deadline. | Narrow the time range, add metric/tag filters, increase the query timeout, or inspect slow storage backends. |
+| `ErrMemoryBudgetExceeded` | `query memory budget exceeded` | Query execution exceeded the configured memory budget. | Reduce cardinality, aggregate earlier, query a smaller range, or raise the query memory budget for the workload. |
+| `ErrInvalidQuery` | `invalid query` | CQL, PromQL, GraphQL, or SQL parsing/validation failed. | Validate syntax, confirm the endpoint expects that query language, and check examples in `docs/API.md`. |
+| `ErrQueryCanceled` | `query canceled` | The request context was canceled before the query completed. | Check client disconnects, HTTP timeouts, parent contexts, and cancellation paths in tests. |
+| `ErrSchemaValidation` | `schema validation failed` | A point does not match the configured schema. | Confirm metric name, value type, required tags, and timestamp units before writing. |
+| `ErrCardinalityLimit` | `cardinality limit exceeded` | A write would create more series than the configured limit allows. | Remove high-cardinality tags such as request IDs, bucket tags, or increase the limit intentionally. |
+| `ErrStorageCorruption` | `storage corruption detected` | Chronicle detected invalid or unreadable persisted data. | Stop writes, preserve the file for inspection, restore from backup if available, and check recent disk or sync failures. |
+| `ErrWALSync` | `WAL sync failed` | A WAL flush or fsync failed. | Check disk space, file permissions, mount health, and whether the filesystem supports durable sync. |
+| `ErrStorageRead` | `storage read failed` | The active storage backend could not read data. | Verify file/object existence, permissions, credentials, network access, and backend configuration. |
+| `ErrStorageWrite` | `storage write failed` | The active storage backend could not persist data. | Check disk space, write permissions, object store credentials, and retry/backoff settings. |
+| `ErrUnsupportedOperation` | `operation not supported` | The selected backend or build does not implement the requested operation. | Check backend capability docs and switch to a backend that supports the operation. |
+| `ErrFeatureDisabled` | `feature is disabled` | A route, integration, or optional module was used while disabled. | Enable the relevant config flag or build option, then restart the service. |
+
+### Typed error wrappers
+
+| Type | Extra context | How to use it |
+|---|---|---|
+| `QueryError` | Query error type, message, query, and cause. | Use `errors.Is(err, ErrInvalidQuery)`, `ErrQueryTimeout`, `ErrMemoryBudgetExceeded`, or `ErrQueryCanceled`; use `errors.As` to log the failing query. |
+| `StorageError` | Storage error type, path, message, and cause. | Use `errors.Is` for `ErrStorageRead`, `ErrStorageWrite`, `ErrStorageCorruption`, or `ErrWALSync`; include `Path` in logs. |
+| `WALSyncError` | Separate flush and sync errors. | Inspect both causes with `errors.As`; when both exist, fix the first durable-write failure before retrying. |
+| `WriteError` | Metric name plus the underlying cause. | Log the metric and unwrap the cause to distinguish schema, cardinality, and storage failures. |
+| `ConfigError` | Invalid config field and message. | Surface the field name to users and fix config before opening the database. |
+
+### HTTP API errors
+
+HTTP handlers serialize failures as:
+
+```json
+{
+  "error": "error message description"
+}
+```
+
+Common responses:
+
+| Status | Usually caused by | First checks |
+|---|---|---|
+| `400 Bad Request` | Invalid JSON, invalid line protocol, invalid CQL/PromQL, bad timestamps, or schema validation. | Re-run with the examples in `docs/API.md`, verify `Content-Type`, and confirm timestamps are in the documented units. |
+| `404 Not Found` | Unknown route, missing resource, or disabled optional endpoint. | Check the exact path and whether the feature is enabled in configuration. |
+| `500 Internal Server Error` | Storage, WAL, plugin, or unexpected server-side failures. | Check server logs for wrapped errors, then follow the matching sentinel error guidance above. |
+
 ## See Also
 
 - [FAQ](FAQ.md) — Common runtime gotchas and debugging tips


### PR DESCRIPTION
## Summary
- Added a `Chronicle Error Reference` section to `docs/TROUBLESHOOTING.md`.
- Documented sentinel errors from `errors.go` with likely causes and troubleshooting steps.
- Added typed wrapper guidance for `QueryError`, `StorageError`, `WALSyncError`, `WriteError`, and `ConfigError`.
- Added a short HTTP API error-response troubleshooting table.

## Testing
- `git diff --cached --check`
- Go is not installed in this workspace, so this docs-only change was not tested with Go commands.

## Bounty / payout
This addresses Chronicle documentation bounty #4: "Improve error messages doc" ($25), listed in `docs/BOUNTY_PROGRAM.md`.

PayPal: https://paypal.me/ShaimaaElkadi
