### PR TITLE
docs: add focused time-series comparisons

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -68,6 +68,77 @@ This document compares Chronicle with other popular time-series databases to hel
 - **You need full SQL compatibility** — TimescaleDB (built on PostgreSQL) or QuestDB offer richer SQL support with JOINs and the full PostgreSQL ecosystem.
 - **Write throughput is your primary concern** — QuestDB and VictoriaMetrics are optimized for very high write throughput in server deployments.
 
+## Focused Comparisons
+
+### Chronicle vs InfluxDB
+
+Choose Chronicle over InfluxDB when the database should live inside a Go
+application, edge gateway, CLI, or browser build. Chronicle keeps deployment
+simple: no separate server process, no sidecar, and no network hop for local
+reads and writes. It is a better fit when the application owns its telemetry
+and needs a compact local store with optional HTTP compatibility.
+
+Choose InfluxDB when you want a mature standalone time-series platform with
+managed cloud options, established operational tooling, and broad ecosystem
+support for InfluxQL, Flux, dashboards, and task scheduling. Chronicle supports
+Influx line protocol ingestion, but it is not a full InfluxDB replacement for
+teams that depend on Flux tasks, cloud management features, or mature cluster
+operations.
+
+| Requirement | Prefer Chronicle | Prefer InfluxDB |
+|---|---|---|
+| Embedded storage | Yes, in-process Go library | No, server-first |
+| Edge devices | Strong fit for local storage | Possible, but heavier |
+| Influx line protocol | Supported for ingestion | Native |
+| Flux compatibility | Not a goal | Native |
+| Managed hosted service | Not the focus | Strong option |
+
+### Chronicle vs VictoriaMetrics
+
+Choose Chronicle over VictoriaMetrics when telemetry should be collected and
+queried close to the application that produces it. Chronicle is designed for
+embedded and edge-first scenarios where local persistence, small operational
+surface area, and direct library calls matter more than centralized ingestion
+throughput.
+
+Choose VictoriaMetrics when you need a high-throughput Prometheus-compatible
+server, long retention, multi-node scaling, and mature operational features for
+large metric fleets. Chronicle can accept Prometheus remote write and provides a
+PromQL subset, but VictoriaMetrics remains the better choice for central metrics
+platforms that rely on full MetricsQL, high availability, and large-scale
+scrape or remote-write fan-in.
+
+| Requirement | Prefer Chronicle | Prefer VictoriaMetrics |
+|---|---|---|
+| In-process database | Yes | No |
+| Central metrics backend | Possible, but not primary | Strong fit |
+| Prometheus remote write | Supported | Native and highly optimized |
+| MetricsQL compatibility | No | Native |
+| Very high write throughput | Good for embedded workloads | Strong fit |
+
+### Chronicle vs Prometheus
+
+Choose Chronicle over Prometheus when metrics need to be pushed into an
+embedded store, retained inside the application, or queried without running a
+separate scraper and TSDB. Chronicle is especially useful for IoT, desktop,
+offline, test, and single-binary deployments where service discovery and pull
+scraping add unnecessary complexity.
+
+Choose Prometheus when you need its pull-based discovery model, mature alerting
+rules, Alertmanager integration, exporter ecosystem, and operational conventions
+for Kubernetes or service-oriented platforms. Chronicle integrates with
+Prometheus-style workflows through remote write and a PromQL subset, but it is
+not intended to replace every Prometheus server feature in monitoring stacks
+that already rely on full PromQL and scrape management.
+
+| Requirement | Prefer Chronicle | Prefer Prometheus |
+|---|---|---|
+| Push-based local writes | Yes | Remote write receiver or gateway required |
+| Pull-based scraping | Optional/integration oriented | Native model |
+| Alertmanager workflow | Not the primary focus | Native ecosystem |
+| Single-binary app storage | Strong fit | No |
+| Full PromQL behavior | Subset support | Native |
+
 ## Architecture Differences
 
 ### Chronicle: Embedded-First


### PR DESCRIPTION
## Summary
- Added focused Chronicle comparisons against InfluxDB, VictoriaMetrics, and Prometheus.
- Clarified when Chronicle is a better fit for embedded, edge, browser, and single-binary deployments.
- Clarified when each alternative is still the better choice for managed hosting, central metrics backends, or full Prometheus workflows.
- Added small decision tables for each comparison.

## Testing
- `git diff --cached --check`
- Go is not installed in this workspace, so this docs-only change was not tested with Go commands.

## Bounty / payout
This addresses Chronicle documentation bounty #5: "Write \"Chronicle vs X\" comparison" ($25), listed in `docs/BOUNTY_PROGRAM.md`.

PayPal: https://paypal.me/ShaimaaElkadi
